### PR TITLE
Updated Preschooler's Place Logic For 2024-2025

### DIFF
--- a/RockWeb/Plugins/org_lakepointe/Finance/PreschoolersPlacePaymentRedirect.lava
+++ b/RockWeb/Plugins/org_lakepointe/Finance/PreschoolersPlacePaymentRedirect.lava
@@ -2,7 +2,8 @@
     Preschooler's place landing page for payemnt scheduling
 {% endcomment %}
 
-{% sql instanceId:'2733' personId:'{{ CurrentPerson.Id }}'%}
+//- When updating: Update instanceId to the new Registration Instance Id
+{% sql instanceId:'3597' personId:'{{ CurrentPerson.Id }}'%}
     SELECT r.Id
     FROM Registration r
     INNER JOIN PersonAlias pa on r.PersonAliasId = pa.Id
@@ -12,17 +13,20 @@
 
 {% assign registrationCount = results | Size %}
 {% assign today = 'Now' | Date:'MM/dd/yyyy' | AsDateTime %}
-{% assign sept1 = '7/1/2023' | Date:'MM/dd/yyyy' |  AsDateTime %}
+//- When updating: Update these two dates to the next year
+{% assign july1 = '7/1/2024' | Date:'MM/dd/yyyy' |  AsDateTime %}
+{% assign sept1 = '9/1/2024' | Date:'MM/dd/yyyy' |  AsDateTime %}
 
-{% capture paymentDate %}{% if today < sept1 %}&paymentDate={{ '9/1/2023' | UrlEncode }}{% endif %}{% endcapture %}
+//- If it's before July 1, set the start date for the payments to September 1
+{% capture paymentDate %}{% if today < july1 %}&paymentDate={{ sept1 | UrlEncode }}{% endif %}{% endcapture %}
 
 {% if registrationCount == 0 %}
     <div class="row">
         <div class="col-xs-12">
             <div class="alert alert-warning">
                 <strong>Can not find registration</strong><br />
-                <p>We are not able to find your Preschooler's Place registration.  Please contact Lori Ham at (469) 698-2300 or
-                    lorih@lakepointe.church for assistance.</p>
+                //- When updating: Make sure this contact info is still correct
+                <p>We are not able to find your Preschooler's Place registration. Please contact Lori Ham at (469) 698-2300 or lori.ham@lakepointe.church for assistance.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This is needed in addition to updating the "Scheduled Payment End Date" and "Available Transaction Frequencies" on the new registration instance. See the Preschooler's Place documentation in Lakepointe's Rockumentation.