### PR TITLE
Check-in Manager Roster - Added Option to Show Schedules That Aren't Active

### DIFF
--- a/RockWeb/Blocks/CheckIn/Manager/Roster.ascx.cs
+++ b/RockWeb/Blocks/CheckIn/Manager/Roster.ascx.cs
@@ -124,6 +124,13 @@ namespace RockWeb.Blocks.CheckIn.Manager
         Description = "When enabled, a 'Move' button will be shown in 'Present' mode allowing the user to move people.",
         DefaultBooleanValue = true,
         Order = 11 )]
+
+    [BooleanField(
+        "Show Schedules That Aren't Currently Active",
+        Key = AttributeKey.ShowInactiveSchedules,
+        Description = "Should schedules that aren't currently active be shown when moving people.",
+        DefaultBooleanValue = true,
+        Order = 12 )]
     // END LPC CODE
 
     #endregion Block Attributes
@@ -158,6 +165,7 @@ namespace RockWeb.Blocks.CheckIn.Manager
 
             // LPC CODE
             public const string EnableMoveButton = "EnableMoveButton";
+            public const string ShowInactiveSchedules = "ShowInactiveSchedules";
             // END LPC CODE
         }
 
@@ -1555,7 +1563,8 @@ namespace RockWeb.Blocks.CheckIn.Manager
 
                 foreach ( var schedule in sortedScheduleList )
                 {
-                    if ( schedule.IsScheduleActive )
+                    bool showInactiveSchedules = GetAttributeValue( AttributeKey.ShowInactiveSchedules ).AsBoolean( true );
+                    if ( schedule.IsScheduleActive || showInactiveSchedules )
                     {
                         ddlMovePersonSchedule.Items.Add( new ListItem( schedule.Name, schedule.Id.ToString() ) );
                     }


### PR DESCRIPTION
Added an option to the Check-in Manager and Pod Manager's roster page to show schedules that aren't currently active. This will allow people to move kids from the 9:30am service to the 11am service before 11am.

Added this as a block setting so that if we decide we don't want this anymore we can easily put it back.