### PR TITLE
Leader Tools - Fixed an issue where serve team members couldn't be edited

### DIFF
--- a/RockWeb/Plugins/org_lakepointe/Groups/GroupRoster.ascx.cs
+++ b/RockWeb/Plugins/org_lakepointe/Groups/GroupRoster.ascx.cs
@@ -593,19 +593,22 @@ namespace RockWeb.Plugins.org_lakepointe.Groups
                 }
                 gmUpdateContext.SaveChanges();
 
-                // make sure the person is in a Member role if they're not already in a Member role or a role that includes "Prospect" (Prospect, Prospective Member) or "Guest"
                 var selectedMemberRoles = cblGroupMemberRole.SelectedValuesAsInt;
-                var memberRole = group.GroupType.Roles.Where( r => r.Name == "Member" ).FirstOrDefault();
-                if ( memberRole != null )
+                if ( group.GroupType.IsSchedulingEnabled == false )
                 {
-                    var isProspect = gmService.Queryable().Where( m =>
-                                                     m.GroupId == groupMember.GroupId &&
-                                                     m.PersonId == groupMember.PersonId &&
-                                                     ( m.GroupRole.Name.Contains( "Prospect" ) || m.GroupRole.Name.Contains( "Guest" ) ) )
-                                                .Any();
-                    if ( !isProspect )
+                    // make sure the person is in a Member role if they're not already in a Member role or a role that includes "Prospect" (Prospect, Prospective Member) or "Guest"
+                    var memberRole = group.GroupType.Roles.Where( r => r.Name == "Member" ).FirstOrDefault();
+                    if ( memberRole != null )
                     {
-                        selectedMemberRoles.Add( memberRole.Id );
+                        var isProspect = gmService.Queryable().Where( m =>
+                                                         m.GroupId == groupMember.GroupId &&
+                                                         m.PersonId == groupMember.PersonId &&
+                                                         ( m.GroupRole.Name.Contains( "Prospect" ) || m.GroupRole.Name.Contains( "Guest" ) ) )
+                                                    .Any();
+                        if ( !isProspect )
+                        {
+                            selectedMemberRoles.Add( memberRole.Id );
+                        }
                     }
                 }
 


### PR DESCRIPTION
This fixes an issue where members of scheduled serve teams couldn't be edited on the Group Roster block on the public site.

This was caused because scheduled serve teams only allow a member to be in the group once, whereas in other groups the person can be in the group multiple times with different roles. The logic I edited was meant to make sure that the person was always at least in the Member role for groups that aren't scheduled. It did this by adding the member role to the list of roles to give the group member. This means that if the user selected the Member role, the Member role would be added to the list a second time by this logic. This would cause the validation logic to see two roles (even though they are the same role). Since scheduled serve team members can't have more than one role in the same group, the validation logic would throw an error.

This fixes that issue by only adding the Member role to the list if the group isn't a scheduled serve team.