### PR TITLE
- Update labels for YCC

### DIFF
--- a/RockWeb/Plugins/org_lakepointe/CheckIn/Labels/Child_Label_and_Slips_v2.lava
+++ b/RockWeb/Plugins/org_lakepointe/CheckIn/Labels/Child_Label_and_Slips_v2.lava
@@ -7,6 +7,7 @@
 
 {% assign isNursery = false %}
 {% assign isSelfReleaseEligible = false %}
+{% assign yccCheckin = false %}
 {% assign memo = '' %}
 
 {% for gt in Person.GroupTypes %}
@@ -20,6 +21,10 @@
 
         {% if gt.Id == 626 or gt.Id == 627 or gt.Id == 340 %}
             {% assign isSelfReleaseEligible = true %}
+        {% endif %}
+
+        {% if gt.Id == 565 %}
+            {% assign yccCheckin = true %}
         {% endif %}
 
         {% if isNursery == false %}
@@ -61,6 +66,7 @@
 
 {% comment %} Determine Person Information {% endcomment %}
 
+{% assign personAge = Person | Property:'Age' %}
 {% assign personAllergy = Person | Attribute:'Allergy' %}
 {% assign personMedicalAlert = Person | Attribute:'Arena-16-81' %}
 {% assign personLegalNotes = Person | Attribute:'LegalNotes' %}
@@ -69,6 +75,10 @@
 {% assign personSelfRelease = Person | Attribute:'Arena-16-384' %}
 {% assign personGrade = Person | Property:'GradeFormatted' %}
 
+{% comment %} Only print child labels for Young Christians Class if attendee is a child {% endcomment %}
+{% if yccCheckin == true and personAge >= 18 %}
+    {% return %}
+{% endif %}
 
 {% comment %} Child Label {% endcomment %}
 

--- a/RockWeb/Plugins/org_lakepointe/CheckIn/Labels/Simple_Volunteer_Label.lava
+++ b/RockWeb/Plugins/org_lakepointe/CheckIn/Labels/Simple_Volunteer_Label.lava
@@ -1,8 +1,30 @@
 {%- comment -%} Simple Volunteer Label for All Campuses {%- endcomment -%}
 
-{%- comment -%}
-    Zebra 200 DPI Label
-{%- endcomment -%}
+{% comment %} Determine Group Information {% endcomment %}
+
+{% assign yccCheckin = false %}
+
+{% for gt in Person.GroupTypes %}
+    {%  for g in gt.Groups %}
+        {% assign groupObject = g.Id | GroupById %}
+
+        {% assign selected = groupObject | Property:'Selected' %}
+        {% if selected == true %}
+            {% continue %}
+        {% endif %}
+
+        {% if gt.Id == 565 %}
+            {% assign yccCheckin = true %}
+        {% endif %}
+
+    {% endfor %}
+{% endfor %}
+
+{% assign personAge = Person | Property:'Age' %}
+{% comment %} Only print adult label for Young Christians Class if attendee is an adult {% endcomment %}
+{% if yccCheckin == true and personAge < 18 %}
+    {% return %}
+{% endif %}
 
 {%- comment -%}
     LABEL HEADER FOR PRINTER
@@ -15,11 +37,12 @@
     Print Name
 {%- endcomment -%}
 ^FO7,67^FB786,1,0,C^A0N,100,100^FH\^FD{{ Person.NickName }}^FS
+^FO7,175^FB786,1,0,C^A0N,60,60^FH\^FD{{ Person.LastName }}^FS
 
 {%- comment -%}
     Print Group Information
 {%- endcomment -%}
-^FO7,275^FB786,1,0,C^A0N,40,40^FH\^FD{{Group.Id | GroupById | Property:'Name'}}^FS
+^FO7,300^FB786,1,0,C^A0N,40,40^FH\^FD{{Group.Id | GroupById | Property:'Name'}}^FS
 
 {%- comment -%}
     LABEL END FOR PRINTER


### PR DESCRIPTION
Both parents and children checkin to YCC.

Updates to only print child label + slips for children, when checking in for YCC.

Updates to only print simple volunteer label for parents, when checking in for YCC.