### PR TITLE
Group Locator - Fixed an Issue Where Filtered Groups Were Shown on the Map

### DIFF
--- a/RockWeb/Plugins/com_bemaservices/GroupTools/Assets/Lava/GroupFinderV6.lava
+++ b/RockWeb/Plugins/com_bemaservices/GroupTools/Assets/Lava/GroupFinderV6.lava
@@ -565,6 +565,14 @@
               mapElement.style.display = 'none';
             {% endif %}
           });
+
+          if (response.data == null || response.data.length <= 0) {
+            document.getElementById('map_wrapper').style.display = 'none';
+          }
+          else {
+            document.getElementById('map_wrapper').style.display = '';
+          }
+
           if (this.bottomVisible()) {
             if (this.groupCount > this.groups.length) {
               this.addGroups();


### PR DESCRIPTION
Fixed an issue with the group locator where the map was not hidden when there were no groups to show on the map. This caused the map to be shown in whatever the previous state was. This led to groups that were filtered out being shown on the map when there were no groups found that met the filters.

This fixes that issue by adding a step after the filtered data is retrieved to hide the map if there are no results.