### PR TITLE
Added Logic To Empty Password Field On Failed Login

### DIFF
--- a/Rock.JavaScript.Obsidian.Blocks/src/Security/Login/credentialLogin.partial.obs
+++ b/Rock.JavaScript.Obsidian.Blocks/src/Security/Login/credentialLogin.partial.obs
@@ -73,7 +73,9 @@
 </template>
 
 <script setup lang="ts">
-    import { computed, PropType, ref } from "vue";
+    // LPC MODIFIED CODE
+    import { computed, PropType, ref, watch } from "vue";
+    // END LPC MODIFIED CODE
     import InlineCheckBox from "@Obsidian/Controls/inlineCheckBox";
     import RockButton from "@Obsidian/Controls/rockButton";
     import RockForm from "@Obsidian/Controls/rockForm";
@@ -104,6 +106,17 @@
         (e: "login", _value: CredentialLoginRequestBag): void,
         (e: "register"): void
     }>();
+
+    // LPC CODE
+    // If the login attempt failed, empty the password field to force the user to re-type it
+    var previousDisabled = false;
+    watch(props, () => {
+        if(previousDisabled == true && props.disabled == false) {
+            password.value = "";
+        }
+        previousDisabled = props.disabled;
+    })
+    // END LPC CODE
 
     // #region Values
 


### PR DESCRIPTION
Added some logic to empty the password field upon a failed login attempt. This was done in order to force the user to re-type their password. This will hopefully reduce the number of times we have people lock out their accounts.

This code works by watching the disabled status of the login form. If the fields are disabled and then re-enabled, that means that the user tried and failed to log in. Therefore, we can empty the password field.

I played with the idea of emptying the password right after the login button is clicked. This works, but it causes the password box to get a red outline before the login is verified. This doesn't look great, and it could be confusing.