### PR TITLE
Bilingual Registrations - Fixed Translation System And Additional Registrar Fields

### DIFF
--- a/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/registrar.partial.obs
+++ b/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/registrar.partial.obs
@@ -28,6 +28,13 @@
                 </div>
                 <!-- END LPC CODE -->
             </div>
+            <!-- LPC CODE -->
+            <div class="row">
+                <div class="col-md-6 col-sm-6">
+                    <StaticFormControl :label="getLang() == 'es' ? 'Idioma Preferido' : 'Preferred Language'" :modelValue="registrar.preferredLanguage ?? ''" />
+                </div>
+            </div>
+            <!-- END LPC CODE -->
         </template>
         <template v-else>
             <div class="row">
@@ -54,6 +61,7 @@
                     <PhoneNumberBox
                                     :label="getLang() == 'es' ? 'Teléfono' : 'Mobile Phone'"
                                     :modelValue="registrar.mobilePhone ?? ''"
+                                    @update:modelValue="registrar.mobilePhone = $event"
                                     rules="required"
                                     tabindex="4" />
                 </div>
@@ -63,6 +71,7 @@
                     <DropDownList
                                   :label="getLang() == 'es' ? 'Idioma Preferido' : 'Preferred Language'"
                                   :modelValue="registrar.preferredLanguage ?? ''"
+                                  @update:modelValue="registrar.preferredLanguage = getFirstString($event)"
                                   :items="languageOptions"
                                   rules="required"
                                   tabIndex="5" />
@@ -286,6 +295,22 @@
     }
 
     // LPC CODE
+    /** Takes in a string or string[]. Returns the first valid string.
+     * If the value is a string, the value is returned.
+     * If the value is a string[], the first element is returned.
+     * Otherwise an empty string is returned. */
+    function getFirstString(value: string | string[]) {
+        if (typeof value == "string") {
+            return value;
+        }
+        else if (value.length > 0) {
+            return value[0];
+        }
+        else {
+            return "";
+        }
+    }
+
     /** Gets the lang parameter from the query string.
      * Returns "en" or "es". Defaults to "en" if invalid. */
     function getLang(): string {

--- a/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/registrationEnd.partial.obs
+++ b/Rock.JavaScript.Obsidian.Blocks/src/Event/RegistrationEntry/registrationEnd.partial.obs
@@ -67,6 +67,59 @@
         if (registrationEntryState.viewModel.registrationAttributesEnd) {
             for (const a of registrationEntryState.viewModel.registrationAttributesEnd) {
                 attrs[a.key ?? ""] = a;
+                
+                // LPC CODE
+                if (getLang() == "es") {
+                    if (a.preHtml != null && a.preHtml != "" && a.configurationValues != null) {
+                        // Get Translations
+                        let optionTranslations = new Map();
+
+                        let el = document.createElement('div');
+                        el.innerHTML = a.preHtml ?? "";
+                        let options = el.getElementsByClassName("SpanishOption");
+                        for (let j = 0; j < options.length; j++) {
+                            optionTranslations.set(options[j].getAttribute("option"), options[j].textContent);
+                        }
+
+                        // Translate Values
+                        let values = a.configurationValues["values"];
+                        let trueText = a.configurationValues["truetext"];
+                        let falseText = a.configurationValues["falsetext"];
+
+                        // Handle Booleans
+                        if (trueText != null && trueText != "") {
+                            if (optionTranslations.has(trueText)) {
+                                a.configurationValues["truetext"] = optionTranslations.get(trueText);
+                            }
+                        }
+                        if (falseText != null && falseText != "") {
+                            if (optionTranslations.has(falseText)) {
+                                a.configurationValues["falsetext"] = optionTranslations.get(falseText);
+                            }
+                        }
+
+                        // Expected values examples:
+                        // [{"value":"1","text":"One"},{"value":"2","text":"Two"},{"value":"3","text":"Three"}]
+                        // [{"value":"1","text":"One","description":"The first value"},{"value":"2","text":"Two","description":"The second value"},{"value":"3","text":"Three","description":"The third value"}]
+                        if (values != null && values != "" && values.includes("value") && values.includes("text")) {
+                            let valuesObjects = JSON.parse(values);
+                            for (let y = 0; y < valuesObjects.length; y++) {
+                                if (valuesObjects[y].hasOwnProperty('text')) {
+                                    let originalText = valuesObjects[y].text;
+                                    if (optionTranslations.has(originalText)) {
+                                        valuesObjects[y].text = optionTranslations.get(originalText);
+                                        if (valuesObjects[y].hasOwnProperty('description')) {
+                                            valuesObjects[y].description = optionTranslations.get(originalText);
+                                        }
+                                    }
+                                }
+                            }
+                            // Replace values property with the results
+                            a.configurationValues["values"] = JSON.stringify(valuesObjects);
+                        }
+                    }
+                }
+                // END LPC CODE
             }
         }
 


### PR DESCRIPTION
Fixed the Registration Attribute options not translating. Copied the logic for translating options from the Registrant form and then adjusted the logic to fit better into this particular form.

Added the missing Preferred Language field to the useLoggedInPersonForRegistrar registrar form.

Added logic to update the Phone Number and Preferred Language when the values in the controls are edited.