### PR TITLE
Signature Documents - Fixed Timeout When Using an Invalid Document Type ID

### DIFF
--- a/RockWeb/Blocks/Core/SignatureDocumentList.ascx.cs
+++ b/RockWeb/Blocks/Core/SignatureDocumentList.ascx.cs
@@ -224,6 +224,23 @@ namespace RockWeb.Blocks.Core
                     var typeColumn = gSignatureDocuments.ColumnsOfType<RockBoundField>().Where( f => f.HeaderText == "Document Type" ).First();
                     typeColumn.Visible = false;
                 }
+                // LPC CODE
+                /*
+                    Jon Corey - 2025-01-28
+
+                    Fixes an issue where when creating a new signature document or using a non-integer parameter
+                    this block would try to load all of the signature documents, which would cause a timeout.
+
+                    This fixes that issue by not running the query if the provided Document Type ID is either 0
+                    or null (non-integer parameters are converted to null).
+                */
+                else
+                {
+                    gSignatureDocuments.DataSource = null;
+                    gSignatureDocuments.DataBind();
+                    return;
+                }
+                // END LPC CODE
             }
 
             var documentListQry = qry.Select( d => new


### PR DESCRIPTION
Fixes an issue where when creating a new signature document or using a non-integer parameter this block would try to load all of the signature documents, which would cause a timeout.

This fixes that issue by not running the query if the provided Document Type ID is either 0 or null (non-integer parameters are converted to null).

*I'm not creating an issue report or pull request on the Spark repo for this since it is fixed in v17 when they swap this block out for the new Obsidian version of this block.*